### PR TITLE
fix(gateway): prevent path traversal in /api/upload target_dir parameter

### DIFF
--- a/agentica/gateway/routes/chat.py
+++ b/agentica/gateway/routes/chat.py
@@ -238,8 +238,17 @@ async def upload_file(
             detail=f"File size {len(content) // 1024}KB exceeds limit of {settings.upload_max_size_mb}MB",
         )
 
-    # Write to destination
-    base = Path(target_dir) if target_dir else settings.workspace_path
+    # Write to destination — enforce that files land inside workspace
+    workspace = settings.workspace_path.resolve()
+    if target_dir:
+        base = Path(target_dir).resolve()
+        if not base.is_relative_to(workspace):
+            raise HTTPException(
+                status_code=400,
+                detail="target_dir must be within the workspace directory",
+            )
+    else:
+        base = workspace
     base.mkdir(parents=True, exist_ok=True)
     dest = base / Path(file.filename or "upload").name
 


### PR DESCRIPTION
Closes #29

## Summary

The `/api/upload` endpoint in `agentica/gateway/routes/chat.py` accepts a user-controlled `target_dir` parameter (via form data) that is used directly to construct the file write destination without any path validation. An attacker can supply a value like `../../etc/cron.d` to write files to arbitrary locations on the host filesystem.

This is a **CWE-22 (Path Traversal)** vulnerability that enables arbitrary file write.

## Affected code

In `agentica/gateway/routes/chat.py`, the `upload_file` function (line 214) takes `target_dir: str = Form("")` and passes it directly to `Path(target_dir)` without verifying the resolved path stays within the workspace directory.

## Preconditions

- The gateway must be network-reachable by the attacker.
- By default, `GATEWAY_TOKEN` is not set, which means authentication is **disabled** (the auth middleware returns early — see `main.py` line 166: `if not settings.gateway_token: return await call_next(request)`). This means the `/api/upload` endpoint is unauthenticated out of the box.

## Proof of Concept

With the gateway running on localhost (default config, no `GATEWAY_TOKEN` set):

```bash
# Write a file outside the workspace using path traversal in target_dir
curl -X POST http://localhost:8080/api/upload \
  -F "file=@malicious.txt" \
  -F "target_dir=../../tmp/pwned"
```

This writes `malicious.txt` to `/tmp/pwned/malicious.txt` (or any other attacker-chosen directory), escaping the intended workspace boundary. An attacker could overwrite configuration files, cron jobs, SSH keys, or other sensitive files depending on the process permissions.

## Fix description

The fix resolves both `target_dir` and the workspace path to absolute paths using `.resolve()`, then checks that `target_dir` is within the workspace using Python's `Path.is_relative_to()`. If the resolved path escapes the workspace boundary, the endpoint returns HTTP 400. When `target_dir` is empty (the default), the workspace path is used directly, preserving existing behavior.

```python
workspace = settings.workspace_path.resolve()
if target_dir:
    base = Path(target_dir).resolve()
    if not base.is_relative_to(workspace):
        raise HTTPException(
            status_code=400,
            detail="target_dir must be within the workspace directory",
        )
else:
    base = workspace
```

## Testing

- Verified that uploads with an empty `target_dir` still write to the workspace directory (existing behavior preserved).
- Verified that uploads with a valid subdirectory of workspace (e.g. `workspace/subdir`) succeed.
- Verified that uploads with a traversal path (e.g. `../../tmp`) are rejected with HTTP 400.
- Verified that symlink-based bypasses are handled because `.resolve()` follows symlinks before the boundary check.

## Adversarial review

Before submitting, we attempted to disprove this finding by checking whether existing auth or middleware would block exploitation. The `auth_middleware` in `main.py` skips authentication entirely when `GATEWAY_TOKEN` is not set, which is the default configuration. There is no other input validation on `target_dir` anywhere in the request pipeline. The `upload_allowed_ext_set` check restricts file extensions but does not restrict the destination directory. We also checked whether the `Path.name` extraction on `file.filename` would prevent exploitation — it sanitizes the filename but not the directory, which is controlled by `target_dir`.

---

<sub>_Submitted by Sebastion — autonomous open-source security research from [Foundation Machines](https://foundationmachines.ai). Free for public repos via the [Sebastion AI GitHub App](https://github.com/apps/sebastionai)._</sub>
